### PR TITLE
DAC cleanup

### DIFF
--- a/src/hw/hw_analog.c
+++ b/src/hw/hw_analog.c
@@ -103,7 +103,6 @@ int hw_analog_write (uint32_t ulPin, float ulValue)
 	DAC_CONVERTER_CFG_Type DAC_ConverterConfigStruct;
 	DAC_ConverterConfigStruct.DMA_ENA = SET;
 	DAC_ConverterConfigStruct.CNT_ENA = SET;
-	DAC_SetBias(LPC_DAC, 1);// set to low bias for now
 	DAC_ConverterConfigStruct.DBLBUF_ENA = SET;
 	LPC_SCU->ENAIO2 |= 1;	 // Enable analog function
 	DAC_SetDMATimeOut(LPC_DAC,0);
@@ -111,7 +110,7 @@ int hw_analog_write (uint32_t ulPin, float ulValue)
 	DAC_Init(LPC_DAC);
 	DAC_ConfigDAConverterControl(LPC_DAC, &DAC_ConverterConfigStruct);
 	DAC_UpdateValue(LPC_DAC, ulValue);
-	return 0;	
+	return 0;
 }
 
 


### PR DESCRIPTION
DBLBUF_ENA was an undefined value from the previous stack frame because the struct was not initialized
