### PR TITLE
no timeout on inactivity

### DIFF
--- a/src/hw/hw_net.c
+++ b/src/hw/hw_net.c
@@ -258,7 +258,7 @@ void hw_net_initialize (void)
  	unsigned long aucDHCP = 14400;
 	unsigned long aucARP = 3600;
 	unsigned long aucKeepalive = 10;
-	unsigned long aucInactivity = 8;
+	unsigned long aucInactivity = 0;
 	if (netapp_timeout_values(&aucDHCP, &aucARP, &aucKeepalive, &aucInactivity) != 0) {
 		TM_DEBUG("Error setting inactivity timeout!");
 	}


### PR DESCRIPTION
We no longer timeout after 8 seconds of socket inactivity. Test scripts are:

`client.js` (tessel)

``` js
var tessel = require('tessel');
var net = require('net');
var i = 0;
var port = 8000;
var host = '192.168.42.65'; // host ip 

client = net.connect(port, host,
    function() { console.log('client connected');
});

client.on('data', function(data) {
    console.log("Got Data: " + data.toString());
});


setInterval(function(){
    i++;
    client.write("Hello from Client #"+i);
}, 30000);
```

`server.js` (node)

``` js
var net = require('net');

var server = net.createServer(function(c) { 
  console.log('Client Online');

  c.on('end', function() {
    console.log('client disconnected');
    c.destroy();
  });

  c.on('data', function(data){
    console.log(data.toString());
  });

  c.write('Online');
  c.pipe(c);
});
server.listen(8000);
console.log("TCP Listening on port " + 8000);
```
