### PR TITLE
Revert "swapping to tm_timestamp to avoid TC wrap"

### DIFF
--- a/src/cc3000/host_spi.c
+++ b/src/cc3000/host_spi.c
@@ -443,12 +443,12 @@ long SpiWrite(unsigned char *pUserBuffer, unsigned short usLength)
 	//
 //	TM_DEBUG("waiting for sSpiInformation.ulSpiState");
 #ifdef CC3K_TIMEOUT
-	double ccStartTime = tm_timestamp();
+	uint32_t ccStartTime = tm_uptime_micro();
 #endif
 	while (eSPI_STATE_IDLE != sSpiInformation.ulSpiState) {
 #ifdef CC3K_TIMEOUT
 		// wait the max of all of our timeouts
-		if (tm_timestamp() - ccStartTime >= CC3000_BLOCKS_WAIT) {
+		if (tm_uptime_micro() - ccStartTime >= CC3000_BLOCKS_WAIT) {
 			TM_DEBUG("Kicking out of CC_BLOCKS");
 			break;
 		}

--- a/src/cc3000/utility/evnt_handler.c
+++ b/src/cc3000/utility/evnt_handler.c
@@ -249,7 +249,7 @@ hci_event_handler(void *pRetParams, unsigned char *from, unsigned char *fromlen)
 	unsigned char *RetParams;
 
 #ifdef CC3K_TIMEOUT
-	double ccStartTime = tm_timestamp();
+	uint32_t ccStartTime = tm_uptime_micro();
 #endif
 
 	while (1)
@@ -508,14 +508,14 @@ hci_event_handler(void *pRetParams, unsigned char *from, unsigned char *fromlen)
 			// If it's not a WLAN event, give it the shorter event wait time
 			if ( ((tSLInformation.usRxEventOpcode <= HCI_CMND_WLAN_CONFIGURE_PATCH 
 					|| tSLInformation.usRxEventOpcode == HCI_EVNT_SOCKET)
-				 	&& tm_timestamp() - ccStartTime >= CC3000_MAX_WAIT) 
+				 	&& tm_uptime_micro() - ccStartTime >= CC3000_MAX_WAIT) 
 				// give HCI_EVNT_CLOSE_SOCKET more time
 				 || ( tSLInformation.usRxEventOpcode == HCI_EVNT_CLOSE_SOCKET 
-				 	&& tm_timestamp() - ccStartTime >= CC3000_CLOSE_SOCKET_WAIT) 
+				 	&& tm_uptime_micro() - ccStartTime >= CC3000_CLOSE_SOCKET_WAIT) 
 				 || (tSLInformation.usRxEventOpcode > HCI_CMND_WLAN_CONFIGURE_PATCH
 				 	&& tSLInformation.usRxEventOpcode != HCI_EVNT_CLOSE_SOCKET
 				 	&& tSLInformation.usRxEventOpcode != HCI_EVNT_SOCKET
-				 	&& tm_timestamp() - ccStartTime >= CC3000_EVENT_WAIT)
+				 	&& tm_uptime_micro() - ccStartTime >= CC3000_EVENT_WAIT)
 				) {
 
 				// set pRetParams to some default values

--- a/src/cc3000/utility/socket.c
+++ b/src/cc3000/utility/socket.c
@@ -121,8 +121,8 @@ HostFlowControlConsumeBuff(int sd)
 // #ifndef SEND_NON_BLOCKING
 
 #ifdef CC3K_TIMEOUT
-	double ccStartTime = tm_timestamp();
-	double ccPollTime = tm_timestamp();
+	uint32_t ccStartTime = tm_uptime_micro();
+	uint32_t ccPollTime = tm_uptime_micro();
 	fd_set readSet;        // Socket file descriptors we want to wake up for, using select()
     FD_ZERO(&readSet);
     FD_SET(sd, &readSet);
@@ -147,8 +147,8 @@ HostFlowControlConsumeBuff(int sd)
 		
 		// every now and then do some select calls to free
 #ifdef CC3K_TIMEOUT
-		if (tm_timestamp() - ccPollTime >= CC3000_EVENT_WAIT) {
-			ccPollTime = tm_timestamp();
+		if (tm_uptime_micro() - ccPollTime >= CC3000_EVENT_WAIT) {
+			ccPollTime = tm_uptime_micro();
 			select(sd + 1, NULL, &readSet, NULL, NULL);
 		}
 #endif
@@ -158,7 +158,7 @@ HostFlowControlConsumeBuff(int sd)
 
 #ifdef CC3K_TIMEOUT
 		// WORKAROUND: sometimes this doesn't work and we need to kick out of this loop
-		if (tm_timestamp() - ccStartTime >= CC3000_BUFFER_WAIT) {
+		if (tm_uptime_micro() - ccStartTime >= CC3000_BUFFER_WAIT) {
 			TM_DEBUG("kicking out of buffer wait");
 			return CC3K_TIMEOUT_ERR;
 		}


### PR DESCRIPTION
See my comment on the PR for why there was no issue with integer wrap: https://github.com/tessel/firmware/pull/88#discussion_r18419604.

This adds an issue, however: if this is made asynchronous and the time is set while a C3000 operation is pending, the time will jump forward and the timeout will happen early. For things like timeouts, you want a monotonic time, not wall clock time. Since firmware has no reason to care about wall clock time, any use of `tm_timestamp` in firmware is suspect. Firmware shouldn't be using floating point, either.
