### PR TITLE
give error handler a chance to attach

### DIFF
--- a/builtin/wifi-cc3000.js
+++ b/builtin/wifi-cc3000.js
@@ -133,8 +133,10 @@ function Wifi(){
   }
 
   self._failProcedure = function (err, callback){
-    self.emit('error', err);
-    if (callback) callback(err);
+    setImmediate(function(){
+      self.emit('error', err);
+      if (callback) callback(err);
+    });
   } 
 
   self.isEnabled = function() {


### PR DESCRIPTION
fixes https://github.com/tessel/runtime/issues/509

Previously this worked:

``` js
wifi.on('error', function(err){
    console.log("error", err);
});

wifi.connect({
    security: "wpa2"
    , ssid: new Buffer("test")
    , password: "test"
    , timeout: 10
});
```

But this did not:

``` js
wifi.connect({
    security: "wpa2"
    , ssid: new Buffer("test")
    , password: "test"
    , timeout: 10
});

wifi.on('error', function(err){
    console.log("error", err);
});
```
