### PR TITLE
Increases SPI timeout.

### DIFF
--- a/test/spi.js
+++ b/test/spi.js
@@ -18,7 +18,7 @@ function testBuf(len) {
 function wrapCallback(t, cb) {
   var timeout = setTimeout(function fail() {
     t.fail("test timed out");
-  }, 1000);
+  }, 3000);
   return function() {
     clearTimeout(timeout);
     cb.apply(null, arguments);


### PR DESCRIPTION
The SPI timeout is hovering at the ~1s mark, which is (in realtime) when the SPI transfer returns. The longest completion time I saw was >2s. 3s leaves a safe buffer for SPI to not race the code while still ensuring the transfer hasn't stalled.
