### PR TITLE
Adds js binding to reset the tessel.

### DIFF
--- a/builtin/tessel.js
+++ b/builtin/tessel.js
@@ -1528,6 +1528,10 @@ function Tessel() {
     return hw.device_id();
   }; 
 
+  this.reset_board = function(){
+	return hw.reset_board();
+  }
+
 }
 
 util.inherits(Tessel, EventEmitter);

--- a/src/hw/l_hw.c
+++ b/src/hw/l_hw.c
@@ -80,6 +80,12 @@ static int l_hw_sleep_ms(lua_State* L)
 	return 0;
 }
 
+static int l_hw_reset_board()
+{
+	tessel_reset_board();
+	return 0;
+}
+
 
 // spi
 
@@ -1101,6 +1107,9 @@ LUALIB_API int luaopen_hw(lua_State* L)
 		{ "wifi_disable", l_wifi_disable },
 		{ "wifi_enable", l_wifi_enable },
 		{ "wifi_mac_address", l_wifi_mac_address},
+
+		//reset
+		{ "reset_board", l_hw_reset_board},
 
 		// End of array (must be last)
 		{ NULL, NULL }

--- a/src/tessel.c
+++ b/src/tessel.c
@@ -16,7 +16,8 @@
 #include "hw.h"
 #include "variant.h"
 
-
+#include "hw/bootloader.h"
+#include "sys/spi_flash.h"
 /**
  * initialize GPIOs for new script
  */
@@ -99,4 +100,9 @@ void tessel_network_reset ()
 	// 	closesocket(2);
 	// 	closesocket(3);
 	// }
+}
+
+void tessel_reset_board ()
+{
+	jump_to_flash(FLASH_FW_ADDR, 0);
 }

--- a/src/tessel.h
+++ b/src/tessel.h
@@ -55,6 +55,8 @@ int populate_fs (const uint8_t *file, size_t len);
 
 int debugstack();
 
+void tessel_reset_board ();
+
 
 /**
  * SPI


### PR DESCRIPTION
Calling tessel.reset_board() in a js program now resets the tessel,
allowing for programmatically reset. Fixes #124.